### PR TITLE
VT-5738 Shipstation order sync error: 'rejected_fulfillment' was not found

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "1.4.10.0" ) ]
+[ assembly : AssemblyVersion( "1.4.11.0" ) ]

--- a/src/ShipStationAccess/ShipStationAccess.csproj
+++ b/src/ShipStationAccess/ShipStationAccess.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ShipStationAccess</RootNamespace>
     <AssemblyName>ShipStationAccess</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/src/ShipStationAccess/V2/Models/Order/ShipStationOrder.cs
+++ b/src/ShipStationAccess/V2/Models/Order/ShipStationOrder.cs
@@ -192,7 +192,8 @@ namespace ShipStationAccess.V2.Models.Order
 		cancelled = 4,
 		on_hold = 5,
 		pending_fulfillment = 6,
-		processing = 7
+		processing = 7,
+		rejected_fulfillment = 8
 		// ReSharper restore InconsistentNaming
 	}
 }

--- a/src/ShipStationAccess/V2/ShipStationService.cs
+++ b/src/ShipStationAccess/V2/ShipStationService.cs
@@ -106,7 +106,11 @@ namespace ShipStationAccess.V2
 					var curOrder = order;
 					if( processedOrderIds.Contains( curOrder.OrderId ) )
 						continue;
-
+					
+					// Orders with status 'rejected_fulfillment' should be ignored. VT-5738
+					if( curOrder.OrderStatus == ShipStationOrderStatusEnum.rejected_fulfillment )
+						continue;
+					
 					if( processOrder != null )
 						curOrder = processOrder( curOrder );
 					orders.Add( curOrder );

--- a/src/ShipStationAccessTests/ShipStationAccessTests.csproj
+++ b/src/ShipStationAccessTests/ShipStationAccessTests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ShipStationAccessTests</RootNamespace>
     <AssemblyName>ShipStationAccessTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>


### PR DESCRIPTION
We should ignore orders with status 'rejected_fulfillment'