### PR TITLE
GUARD-2926-add-shipstation-logging

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -81,6 +81,7 @@ task NuGet Package, Version, {
 		<owners>Agile Harbor</owners>
 		<projectUrl>https://github.com/agileharbor/$project_name</projectUrl>
 		<licenseUrl>https://raw.github.com/agileharbor/$project_name/master/License.txt</licenseUrl>
+		<repository type="git" url="https://github.com/skuvault-integrations/shipStationAccess.git" />
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<copyright>Copyright (C) Agile Harbor, LLC</copyright>
 		<summary>$text</summary>
@@ -112,4 +113,4 @@ task NuGet Package, Version, {
 	}
 }
 
-task . Init, Build, Package, Zip, NuGet
+task . Init, Build, Package, NuGet

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ _ReSharper*/
 [Tt]est[Rr]esult*
 *.ReSharper
 *.docstates
+.idea/
+.vs/
 
 #Ignore common build files
 build

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "1.5.0.0" ) ]
+[ assembly : AssemblyVersion( "1.5.0.1-alpha" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "1.4.12.0" ) ]
+[ assembly : AssemblyVersion( "1.5.0.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "1.5.0.1" ) ]
+[ assembly : AssemblyVersion( "1.5.1" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "1.5.0.1-alpha" ) ]
+[ assembly : AssemblyVersion( "1.5.0.1" ) ]

--- a/src/ShipStationAccess/Constants.cs
+++ b/src/ShipStationAccess/Constants.cs
@@ -1,0 +1,14 @@
+﻿using System.Diagnostics;
+using System.Reflection;
+
+namespace ShipStationAccess
+{
+    /// <summary>
+    /// Project-wise constants.
+    /// </summary>
+    internal static class Constants
+    {
+        public static readonly string VersionInfo = FileVersionInfo.GetVersionInfo( Assembly.GetExecutingAssembly().Location ).FileVersion;
+        public const string ChannelName = "shipstation";
+    }
+}

--- a/src/ShipStationAccess/Constants.cs
+++ b/src/ShipStationAccess/Constants.cs
@@ -9,6 +9,6 @@ namespace ShipStationAccess
     internal static class Constants
     {
         public static readonly string VersionInfo = FileVersionInfo.GetVersionInfo( Assembly.GetExecutingAssembly().Location ).FileVersion;
-        public const string ChannelName = "shipstation";
+        public const string IntegrationName = "shipstation";
     }
 }

--- a/src/ShipStationAccess/ShipStationAccess.csproj
+++ b/src/ShipStationAccess/ShipStationAccess.csproj
@@ -81,6 +81,7 @@
     <Compile Include="..\Global\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Constants.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ShipStationFactory.cs" />
     <Compile Include="V2\Exceptions\ShipStationUnrecoverableException.cs" />

--- a/src/ShipStationAccess/V2/Services/WebRequestServices.cs
+++ b/src/ShipStationAccess/V2/Services/WebRequestServices.cs
@@ -268,11 +268,14 @@ namespace ShipStationAccess.V2.Services
 		private void ThrowIfError( string url, HttpResponseMessage responseMessage, string responseContent )
 		{
 			var serverStatusCode = responseMessage.StatusCode;
-
-			if ( serverStatusCode == HttpStatusCode.Unauthorized )
+			if( serverStatusCode == HttpStatusCode.Unauthorized )
+			{
+				//ShipStationLogger.Log.Info( "[shipstation]\tRequest to '{url}' returned HTTP 401 Error with the response content: '{responseContent}'. Request Headers: {responseMessage.RequestMessage.Headers}, Response Headers: {responseMessage.Headers}", url, responseContent, responseMessage.RequestMessage.Headers, responseMessage.Headers );
+				ShipStationLogger.Log.Info( $"[shipstation]\tRequest to '{url}' returned HTTP 401 Error with the response content: '{responseContent}'. Request Headers: {responseMessage.RequestMessage.Headers}, Response Headers: {responseMessage.Headers}" );
 				throw new ShipStationUnauthorizedException();
+			}
 
-			if ( IsRequestThrottled( responseMessage, responseContent, out int rateResetInSeconds ) )
+			if( IsRequestThrottled( responseMessage, responseContent, out int rateResetInSeconds ) )
 			{
 				ShipStationLogger.Log.Info( "[shipstation]\tResponse for apiKey '{apiKey}' and url '{uri}':\n{resetInSeconds} - {isThrottled}\n{response}",
 									this._credentials.ApiKey, url, rateResetInSeconds, true, responseContent );

--- a/src/ShipStationAccess/V2/Services/WebRequestServices.cs
+++ b/src/ShipStationAccess/V2/Services/WebRequestServices.cs
@@ -270,8 +270,8 @@ namespace ShipStationAccess.V2.Services
 			var serverStatusCode = responseMessage.StatusCode;
 			if( serverStatusCode == HttpStatusCode.Unauthorized )
 			{
-				//ShipStationLogger.Log.Info( "[shipstation]\tRequest to '{url}' returned HTTP 401 Error with the response content: '{responseContent}'. Request Headers: {responseMessage.RequestMessage.Headers}, Response Headers: {responseMessage.Headers}", url, responseContent, responseMessage.RequestMessage.Headers, responseMessage.Headers );
-				ShipStationLogger.Log.Info( $"[shipstation]\tRequest to '{url}' returned HTTP 401 Error with the response content: '{responseContent}'. Request Headers: {responseMessage.RequestMessage.Headers}, Response Headers: {responseMessage.Headers}" );
+				//ShipStationLogger.Log.Info( "[shipstation]\tRequest to '{url}' returned HTTP Error with the response content: '{responseContent}'. Request Headers: {responseMessage.RequestMessage.Headers}, Response Headers: {responseMessage.Headers}", url, responseContent, responseMessage.RequestMessage.Headers, responseMessage.Headers );
+				ShipStationLogger.Log.Info( $"[shipstation]\tRequest to '{url}' returned HTTP Error with the response content: '{responseContent}'. Request Headers: {responseMessage.RequestMessage.Headers}, Response Headers: {responseMessage.Headers}" );
 				throw new ShipStationUnauthorizedException();
 			}
 

--- a/src/ShipStationAccess/V2/Services/WebRequestServices.cs
+++ b/src/ShipStationAccess/V2/Services/WebRequestServices.cs
@@ -268,11 +268,17 @@ namespace ShipStationAccess.V2.Services
 		private void ThrowIfError( string url, HttpResponseMessage responseMessage, string responseContent )
 		{
 			var serverStatusCode = responseMessage.StatusCode;
+			var apiKey = this._credentials.ApiKey;
+			const int maxApiKeyChars = 10;
+			
 			if( serverStatusCode == HttpStatusCode.Unauthorized )
 			{
-				ShipStationLogger.Log.Info( "[{IntegrationName}] [{Version}]\tRequest to '{Url}' returned HTTP Error with the response content: '{ResponseContent}'. Request Headers: {RequestMessageHeaders}, Response Headers: {ResponseMessageHeaders}",
+				// All ApiKey information will be removed later in GUARD-2930. For now, we only have this field to identify the account.
+				var apiKeyFirstTen = apiKey?.Length > 10 ? apiKey.Substring(0, maxApiKeyChars) + "..." : apiKey;
+				ShipStationLogger.Log.Info( "[{IntegrationName}] [{Version}] [{TruncatedApiKey}]\tRequest to '{Url}' returned HTTP Error with the response content: '{ResponseContent}'. Request Headers: {@RequestMessageHeaders}, Response Headers: {@ResponseMessageHeaders}",
 					Constants.IntegrationName,
 					Constants.VersionInfo,
+					apiKeyFirstTen,
 					url,
 					responseContent,
 					responseMessage?.RequestMessage?.Headers,

--- a/src/ShipStationAccess/V2/Services/WebRequestServices.cs
+++ b/src/ShipStationAccess/V2/Services/WebRequestServices.cs
@@ -270,11 +270,11 @@ namespace ShipStationAccess.V2.Services
 			var serverStatusCode = responseMessage.StatusCode;
 			if( serverStatusCode == HttpStatusCode.Unauthorized )
 			{
-				ShipStationLogger.Log.Info( "[{Channel}] [{Version}]\tRequest to '{Url}' returned HTTP Error with the response content: '{ResponseContent}'. Request Headers: {RequestMessageHeaders}, Response Headers: {ResponseMessageHeaders}", 
-					Constants.ChannelName, 
+				ShipStationLogger.Log.Info( "[{IntegrationName}] [{Version}]\tRequest to '{Url}' returned HTTP Error with the response content: '{ResponseContent}'. Request Headers: {RequestMessageHeaders}, Response Headers: {ResponseMessageHeaders}",
+					Constants.IntegrationName,
 					Constants.VersionInfo,
 					url,
-					responseContent, 
+					responseContent,
 					responseMessage?.RequestMessage?.Headers,
 					responseMessage?.Headers );
 				throw new ShipStationUnauthorizedException();
@@ -283,13 +283,13 @@ namespace ShipStationAccess.V2.Services
 			if( !this.IsRequestThrottled( responseMessage, responseContent, out int rateResetInSeconds ) )
 				return;
 			
-			ShipStationLogger.Log.Info( "[{Channel}] [{Version}]\tResponse for apiKey '{ApiKey}' and url '{Uri}':\n{ResetInSeconds} - {IsThrottled}\n{Response}",
-				Constants.ChannelName, 
+			ShipStationLogger.Log.Info( "[{IntegrationName}] [{Version}]\tResponse for apiKey '{ApiKey}' and url '{Uri}':\n{ResetInSeconds} - {IsThrottled}\n{Response}",
+				Constants.IntegrationName,
 				Constants.VersionInfo,
-				this._credentials.ApiKey, 
-				url, 
-				rateResetInSeconds, 
-				true, 
+				this._credentials.ApiKey,
+				url,
+				rateResetInSeconds,
+				true,
 				responseContent );
 			throw new ShipStationThrottleException( rateResetInSeconds );
 		}


### PR DESCRIPTION
# Description
Tickets: [GUARD-2926]
Goal: to provide more content about the 401 error before throwing ShipStationUnauthorizedException.

## Background
Currently, we throw ShipStationUnauthorizedException exception without logging any additional information about the error.
This information would help us to diagnose why and which request returns the 401 Unauthorized error. 

## About the changes in this PR
Added logging by following the existing pattern.

Example log from unit testing:
`2023-05-03 17:34:42 [Information] ["shipstation"] ["1.5.1.0"] ["f7d81aea66..."]	Request to '"https://ssapi.shipstation.com/Orders/List?createDateStart=2023-04-23T21:34:22-00:00&createDateEnd=2023-05-03T21:34:22-00:00&pageSize=20&page=1"' returned HTTP Error with the response content: '"401 Unauthorized"'. Request Headers: [KeyValuePair`2 { Key: "Authorization", Value: ["Basic ZjdkODFhZWE2Njg2NDk2MDhhMjAyOGE2NDQ5YmUwZTUxOTRmYTVmOS1mN2QyLTRhZGEtYjlhYy00ZTk0NDNhYWUwZDg6Y2QyZjVhMmIwOTFmNDM2Yjg0NWQ4YmFiMmRjZjAyNDE="] }], Response Headers: [KeyValuePair`2 { Key: "X-Rate-Limit-Limit", Value: ["40"] }, KeyValuePair`2 { Key: "X-Rate-Limit-Remaining", Value: ["40"] }, KeyValuePair`2 { Key: "X-Rate-Limit-Reset", Value: ["37"] }, KeyValuePair`2 { Key: "Connection", Value: ["keep-alive"] }, KeyValuePair`2 { Key: "Date", Value: ["Wed, 03 May 2023 21:34:42 GMT"] }, KeyValuePair`2 { Key: "WWW-Authenticate", Value: ["Basic realm=\"shipstation\""] }]`

# Type of change <!-- should only be one -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality change (fix or feature that would cause existing functionality to work differently than before)
- [ ] Configuration change
- [ ] New / updated script
- [x] Refactoring
- [ ] New tests to existing code

# PR Readiness Checklist
- [x] Followed [development conventions][1] to the best of my ability
- [ ] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [ ] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [ ] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-2926]: https://agileharbor.atlassian.net/browse/GUARD-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ