### PR TITLE
GUARD-2930 Remove ApiKey from logs and add SyncRunContext instead

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -48,7 +48,7 @@ task Package  {
 # Set $script:Version = assembly version
 task Version {
 	assert (( Get-Item $build_artifacts_dir\$project_name.dll ).VersionInfo.FileVersion -match '^(\d+\.\d+\.\d+)')
-	$script:Version = $matches[1] + '-alpha.1'
+	$script:Version = $matches[1]
 }
 
 task Archive {
@@ -109,7 +109,7 @@ task NuGet Package, Version, {
 	$push_project = Read-Host "Push $($project_name) " $Version " to NuGet? (Y/N)"
 	Write-Host $push_project
 	if( $push_project -eq "y" -or $push_project -eq "Y" )	{
-		Get-ChildItem $build_dir\*.nupkg |% { exec { & $nuget push  $_.FullName -Source nuget.org }}
+		Get-ChildItem $build_dir\*.nupkg |% { exec { & $nuget push  $_.FullName -Source https://nuget.pkg.github.com/skuvault-integrations }}
 	}
 }
 


### PR DESCRIPTION
# Description

Tickets: [GUARD-2930] 

Summary: Update package version

## Background

Logs should not contain ApiKey as it is sensitive information

## About these changes

Update package version

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [x] I have updated all relevant configuration
- [ ] Followed [development conventions][1] to the best of my ability
- [ ] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [ ] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-2930]: https://agileharbor.atlassian.net/browse/GUARD-2930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ