### PR TITLE
GUARD-3049 Improve Orders Sync

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -76,7 +76,7 @@ task NuGet Package, Version, {
 <package>
 	<metadata>
 		<id>$project_name</id>
-		<version>$Version</version>
+		<version>$Version-alpha</version>
 		<authors>Agile Harbor</authors>
 		<owners>Agile Harbor</owners>
 		<projectUrl>https://github.com/agileharbor/$project_name</projectUrl>

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.6.1" ) ]
+[ assembly : AssemblyVersion( "1.7.1" ) ]

--- a/src/ShipStationAccess/V2/IShipStationService.cs
+++ b/src/ShipStationAccess/V2/IShipStationService.cs
@@ -21,7 +21,9 @@ namespace ShipStationAccess.V2
 		ShipStationOrder GetOrderById( string orderId, CancellationToken token );
 		Task< ShipStationOrder > GetOrderByIdAsync( string orderId, CancellationToken token );
 		Task< IEnumerable< ShipStationOrderShipment > > GetOrderShipmentsByIdAsync( string orderId, CancellationToken token );
+		Task< IEnumerable< ShipStationOrderShipment > > GetOrderShipmentsByCreatedDateAsync( DateTime createdDate, CancellationToken token );
 		Task< IEnumerable< ShipStationOrderFulfillment > > GetOrderFulfillmentsByIdAsync( string orderId, CancellationToken token );
+		Task< IEnumerable< ShipStationOrderFulfillment > > GetOrderFulfillmentsByCreatedDateAsync( DateTime createdDate, CancellationToken token );
 		
 		void UpdateOrder( ShipStationOrder order, CancellationToken token );
 		Task UpdateOrderAsync( ShipStationOrder order, CancellationToken token );

--- a/src/ShipStationAccess/V2/Models/Order/ShipStationOrderFulfillment.cs
+++ b/src/ShipStationAccess/V2/Models/Order/ShipStationOrderFulfillment.cs
@@ -11,13 +11,13 @@ namespace ShipStationAccess.V2.Models.Order
 		public IEnumerable< ShipStationOrderFulfillment > Fulfillments { get; set; }
 
 		[ DataMember( Name = "total" ) ]
-		public int Total { get; set; }
+		public int TotalFulfillments { get; set; }
 
 		[ DataMember( Name = "page" ) ]
 		public int Page { get; set; }
 
 		[ DataMember( Name = "pages" ) ]
-		public int Pages { get; set; }
+		public int TotalPages { get; set; }
 	}
 
 	[ DataContract ]

--- a/src/ShipStationAccess/V2/Models/Order/ShipStationOrderShipment.cs
+++ b/src/ShipStationAccess/V2/Models/Order/ShipStationOrderShipment.cs
@@ -11,13 +11,13 @@ namespace ShipStationAccess.V2.Models.Order
 		public IEnumerable< ShipStationOrderShipment > Shipments { get; set; }
 
 		[ DataMember( Name = "total" ) ]
-		public int Total { get; set; }
+		public int TotalShipments { get; set; }
 
 		[ DataMember( Name = "page" ) ]
 		public int Page { get; set; }
 
 		[ DataMember( Name = "pages" ) ]
-		public int Pages { get; set; }
+		public int TotalPages { get; set; }
 	}
 
 	[ DataContract ]

--- a/src/ShipStationAccess/V2/Services/ParamsBuilder.cs
+++ b/src/ShipStationAccess/V2/Services/ParamsBuilder.cs
@@ -40,9 +40,22 @@ namespace ShipStationAccess.V2.Services
 			return endpoint;
 		}
 
+		public static string CreateOrderShipmentsParams( DateTime createdDate, bool includeShipmentItems = true )
+		{
+			var endpoint = string.Format( "?{0}={1}&{2}={3}",
+				ShipStationParam.OrdersCreatedDateFrom.Name, createdDate.ToString( "s" ),
+				ShipStationParam.IncludeShipmentItems.Name, includeShipmentItems );
+			return endpoint;
+		}
+
 		public static string CreateOrderFulfillmentsParams( string orderId )
 		{
 			return string.Format( "?{0}={1}", ShipStationParam.OrderId.Name, orderId );
+		}
+
+		public static string CreateOrderFulfillmentsParams( DateTime createdDate )
+		{
+			return string.Format( "?{0}={1}", ShipStationParam.OrdersCreatedDateFrom.Name, createdDate.ToString( "s" ) );
 		}
 
 		public static string CreateGetNextPageParams( ShipStationCommandConfig config )

--- a/src/ShipStationAccess/V2/ShipStationService.cs
+++ b/src/ShipStationAccess/V2/ShipStationService.cs
@@ -465,13 +465,13 @@ namespace ShipStationAccess.V2
 		{
 			var ordersList = orders.ToList();
 			var minOrderDate = ordersList.Min( o => o.CreateDate );
-			var shipments = await this.GetOrderShipmentsByCreatedDateAsync( minOrderDate, token ).ConfigureAwait( false );
-			var fulfillments = await this.GetOrderFulfillmentsByCreatedDateAsync( minOrderDate, token ).ConfigureAwait( false );
+			var shipments = ( await this.GetOrderShipmentsByCreatedDateAsync( minOrderDate, token ).ConfigureAwait( false ) ).ToList();
+			var fulfillments = ( await this.GetOrderFulfillmentsByCreatedDateAsync( minOrderDate, token ).ConfigureAwait( false ) ).ToList();
 
 			foreach( var order in ordersList )
 			{
-				order.Shipments = shipments.ToList().Where( s => s.OrderId == order.OrderId );
-				order.Fulfillments = fulfillments.ToList().Where( f => f.OrderId == order.OrderId );
+				order.Shipments = shipments.Where( s => s.OrderId == order.OrderId ).ToList();
+				order.Fulfillments = fulfillments.Where( f => f.OrderId == order.OrderId ).ToList();
 			}
 		}
 

--- a/src/ShipStationAccess/V2/ShipStationService.cs
+++ b/src/ShipStationAccess/V2/ShipStationService.cs
@@ -459,7 +459,7 @@ namespace ShipStationAccess.V2
 		}
 
 		/// <summary>
-		/// Uses the minimum order's 'createDate' value to fetch all shipments and fulfillments created on or after that date.
+		/// Uses the minimum order's 'createDate' value to fetch all shipments and fulfillments created on or after that date, and updates the corresponding collections in the orders list.
 		/// </summary>
 		private async Task GetShipmentsAndFullfilmentsByCreationDate( IEnumerable< ShipStationOrder > orders, CancellationToken token )
 		{
@@ -476,7 +476,7 @@ namespace ShipStationAccess.V2
 		}
 
 		/// <summary>
-		/// Makes two separate calls to ShipStation's API to obtain shipments and fulfillment data per each order.
+		/// Makes two separate calls to ShipStation's API to obtain shipments and fulfillment data per each order and updates the corresponding collections in the orders list.
 		/// </summary>
 		private async Task GetShipmentsAndFullfilmentByOrderId( IEnumerable< ShipStationOrder > orders, CancellationToken token )
 		{
@@ -510,7 +510,7 @@ namespace ShipStationAccess.V2
 					break;
 
 				++currentPage;
-				totalShipStationShipmentsPages = ordersShipmentsPage.Pages + 1;
+				totalShipStationShipmentsPages = ordersShipmentsPage.TotalPages + 1;
 
 				orderShipments.AddRange( ordersShipmentsPage.Shipments );
 			}
@@ -542,7 +542,7 @@ namespace ShipStationAccess.V2
 					break;
 
 				++currentPage;
-				totalShipStationShipmentsPages = ordersShipmentsPage.Pages + 1;
+				totalShipStationShipmentsPages = ordersShipmentsPage.TotalPages + 1;
 
 				orderShipments.AddRange( ordersShipmentsPage.Shipments );
 			}
@@ -574,7 +574,7 @@ namespace ShipStationAccess.V2
 					break;
 
 				++currentPage;
-				totalShipStationFulfillmentsPages = orderFulfillmentsPage.Pages + 1;
+				totalShipStationFulfillmentsPages = orderFulfillmentsPage.TotalPages + 1;
 
 				orderFulfillments.AddRange( orderFulfillmentsPage.Fulfillments );
 			}
@@ -606,7 +606,7 @@ namespace ShipStationAccess.V2
 					break;
 
 				++currentPage;
-				totalShipStationFulfillmentsPages = orderFulfillmentsPage.Pages + 1;
+				totalShipStationFulfillmentsPages = orderFulfillmentsPage.TotalPages + 1;
 
 				orderFulfillments.AddRange( orderFulfillmentsPage.Fulfillments );
 			}

--- a/src/ShipStationAccessTests/Orders/OrderTests.cs
+++ b/src/ShipStationAccessTests/Orders/OrderTests.cs
@@ -23,6 +23,8 @@ namespace ShipStationAccessTests.Orders
 	{
 		private const string TestOrderWithShipments = "564221696";
 		private const string TestOrderWithFulfillments = "576752152";
+		private readonly DateTime TestOrderWithShipmentsCreatedDate = new DateTime( 2020, 6, 10 );
+		private readonly DateTime TestOrderWithFulfillmentsCreatedDate = new DateTime( 2020, 7, 20 );
 
 		[Test]
 		public void DeserializeOrderWithNullablePaymentDateTest()
@@ -213,6 +215,24 @@ namespace ShipStationAccessTests.Orders
 		public async Task GetOrderFulfillmentsAsync()
 		{
 			var orderFulfillments = await this._shipStationService.GetOrderFulfillmentsByIdAsync( TestOrderWithFulfillments, CancellationToken.None );
+
+			orderFulfillments.Count().Should().BeGreaterThan( 0 );
+		}
+
+		[ Test ]
+		[ Explicit ]
+		public async Task GetOrderShipmentsByCreatedDateAsync_ShouldReturnOrdersWithShipments()
+		{
+			var orderShipments = await this._shipStationService.GetOrderShipmentsByCreatedDateAsync( TestOrderWithShipmentsCreatedDate, CancellationToken.None );
+
+			orderShipments.Count().Should().BeGreaterThan( 0 );
+		}
+
+		[ Test ]
+		[ Explicit ]
+		public async Task GetOrderFulfillmentsByCreatedDateAsync_ShouldReturnOrdersWithFullfilments()
+		{
+			var orderFulfillments = await this._shipStationService.GetOrderFulfillmentsByCreatedDateAsync( TestOrderWithFulfillmentsCreatedDate, CancellationToken.None );
 
 			orderFulfillments.Count().Should().BeGreaterThan( 0 );
 		}


### PR DESCRIPTION
# Description

Tickets: [GUARD-3049] <!-- Replace with appropriate tickets. Some automation depend on this section, don't remove -->

Summary: Increased page size from 20 to 500 and improved orders sync processing by retrieving shipment and fulfillment data based on creation date, instead of having duplicate API calls per order.

## Background

Occasionally, the Orders Sync process may not complete within a day due to the presence of large catalogs, which is why we needed to improve the sync response time.

## About these changes

- Added two methods (`GetOrderShipmentsByCreatedDateAsync` and `GetOrderFulfillmentsByCreatedDateAsync`)  to help processing orders shipments and fulfillment data when number of orders is too large ( > 10 )
- Increased request page size from 20 to 500 (max allowed)
- Added integration tests

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [X] I have updated all relevant configuration
- [X] Followed [development conventions][1] to the best of my ability
- [X] Code is documented, particularly public interfaces and hard-to-understand areas
- [X] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-3049]: https://agileharbor.atlassian.net/browse/GUARD-3049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ